### PR TITLE
docs: split the README, add AGENTS.md and a /docs page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,198 @@
+# AGENTS.md
+
+A Vite + Vue 3 starter template, deployed to Cloudflare Workers at
+[vue-starter.raz.wtf](https://vue-starter.raz.wtf). It is a template, so the code is meant to be read
+as an example: prefer clarity and an explanatory comment over cleverness.
+
+`README.md` and `docs/reference.md` are the human-facing docs — and both are also **rendered as pages
+of the app**, so editing them changes the deployed site. Keep them in sync when you change behaviour
+they describe.
+
+`CLAUDE.md` is a symlink to this file. Edit `AGENTS.md`; never replace the symlink with a copy.
+
+## Setup commands
+
+Requires **Node 26** (see `.nvmrc`) and **pnpm 11**. `engines.node` is `>=26.0.0`, which pnpm enforces
+as a hard install failure.
+
+```sh
+pnpm install       # deps + git hooks (prepare -> lefthook install)
+pnpm dev           # dev server on :5173
+pnpm build         # vue-tsc --build && vite build
+pnpm build-only    # vite build, no type-check
+pnpm preview       # production build on :4173
+```
+
+## Verify your work
+
+Run these before you consider a task finished. `pnpm check` is the single gate that CI and the
+`pre-push` hook both use:
+
+```sh
+pnpm check         # lint + format:check + type-check  <- the one to run
+pnpm test          # unit tests (vitest run)
+pnpm test:e2e      # playwright; run `pnpm exec playwright install` once first
+```
+
+Individually: `pnpm lint`, `pnpm lint:fix`, `pnpm format`, `pnpm format:check`, `pnpm type-check`,
+`pnpm test:watch`.
+
+If you touched routes, components or composables, also confirm the generated declarations are current
+— CI fails on a diff here:
+
+```sh
+git diff --exit-code -- auto-imports.d.ts components.d.ts src/typed-router.d.ts
+```
+
+E2E runs against the dev server locally and against `vite preview` under CI. To reproduce the CI
+path, build first:
+
+```sh
+pnpm build && CI=1 pnpm test:e2e
+```
+
+## Architecture
+
+```
+src/
+  main.ts            entry: Pinia, Vue Query, Unhead, and `await startMockApi()` before mount
+  App.vue            resolves the layout via import.meta.glob on route.meta.layout
+  pages/             file-based routes (.vue only)
+  layouts/           DefaultLayout (app chrome), EmptyLayout (bare)
+  components/        auto-imported; Demo/ and Ui/ are namespaced by directory
+  composables/       auto-imported by name, no import line needed
+  schemas/           zod schemas — the single source of truth per resource
+  api/               fetch + zod parse; the only place that knows about the network
+  mocks/             MSW: handlers.ts, db.ts, browser.ts (worker), node.ts (setupServer)
+  stores/            Pinia
+  test/setup.ts      starts the MSW node server for every unit suite
+docs/reference.md    the /docs page
+```
+
+The `/demo` page is one resource — a members list — deliberately wired through the whole stack:
+
+```
+schemas/member.ts -> mocks/handlers.ts -> api/members.ts -> composables/useMembers.ts -> components/Demo/
+   contract              the API            the boundary          the state                  the UI
+```
+
+Preserve that direction when you extend it. Specifically:
+
+- **Parse at the boundary, never cast.** `api/members.ts` runs `memberListSchema.parse()` on every
+  response so a renamed backend field fails loudly in one file.
+- **Mutations invalidate, they do not patch the cache.** `useMembers()` invalidates the `['members']`
+  key and refetches, because the server owns `id`, `commits` and `joinedAt`.
+- **Components never see a query key or a `fetch`.** `MemberForm` emits a validated value; that is why
+  it unit-tests without a server.
+- **One zod schema does three jobs** — validates the form, parses the response, infers the types. Add
+  a field in `src/schemas/` and nowhere else.
+
+## Code style
+
+Formatting is **oxfmt**, not Prettier, configured in `.oxfmtrc.json`. Do not hand-format; run
+`pnpm format`. The settings that matter: no semicolons, single quotes, trailing commas, 100-column
+print width, 2-space indent, LF endings. Imports are sorted by oxfmt (`sortImports`) — leave the
+order alone.
+
+Linting is **oxlint** (`.oxlintrc.json`), with Vue `<template>` rules from `oxlint-plugin-vize`. There
+is no ESLint and no Prettier in this repo; do not add them, and do not add config for them.
+
+Vue conventions:
+
+- **Composition API with `<script setup lang="ts">`**, always. No Options API, no plain `<script>`.
+- **`definePage({ meta: { layout, title, description } })`** in every page component — `App.vue` reads
+  `meta.layout` and `useSeoMeta` reads the other two.
+- **Typed refs are enforced** (`vue/require-typed-ref`), as is `vue/prefer-import-from-vue`.
+- **No `v-html`** (`vize/vue/no-v-html` is an error).
+- **Do not add import lines for auto-imported things**: Vue, Vue Router, Pinia and VueUse APIs,
+  everything in `src/composables/`, every component under `src/components/`, and every Reka UI
+  primitive all resolve by name. `vue/no-import-compiler-macros` will flag importing the macros.
+- **Style Reka UI primitives with `data-[state=…]` variants**, not a ternary over your own state — the
+  primitive already tracks checked/open/closed and exposes it as an attribute.
+- **Do not reach for a primitive where the platform is already correct.** Plain `<input>` with
+  `<label for>` and a real checkbox are the right answer in `MemberForm`; Reka UI is there for roving
+  focus, focus trapping, ARIA wiring and Escape handling.
+- **UnoCSS utility classes**, with `transformerVariantGroup` available: write
+  `dark:(bg-gray-900 text-gray-50)`. Icons are classes: `<div class="i-lucide-house" />`, Lucide only.
+  There is no class-order lint, so match the surrounding files by hand.
+
+## Testing
+
+- Unit tests live at `src/**/*.spec.ts` and run under Vitest in jsdom. `src/test/setup.ts` starts the
+  MSW node server with `onUnhandledRequest: 'error'` and resets the in-memory db between tests — the
+  db is module state that would otherwise leak one test's POST into the next test's GET.
+- E2E tests live at `e2e/*.spec.ts` and drive the real service worker in a real browser via Playwright.
+- **Both layers share `src/mocks/handlers.ts`.** Add a handler there and both see it.
+- Add or update tests for what you change. Assert accessible semantics (roles, accessible
+  descriptions, focus) rather than CSS classes — that is what the existing e2e specs do, and it is the
+  point of the Reka UI conversions.
+
+## Traps
+
+These have each cost real time. Do not undo them.
+
+1. **`node_modules` must NOT be added to `ignorePatterns` in `.oxlintrc.json`.** The `oxlint-vize`
+   wrapper stages temporary copies of scriptless SFCs under `node_modules/.vize/`; ignoring that path
+   silently disables every template rule while still exiting 0.
+2. **`pnpm lint` runs `oxlint-vize`, not `oxlint`.** Plain `oxlint` silently skips `.vue` files with
+   no `<script>` block, and two components here are scriptless. `pnpm lint:fix` stays on plain
+   `oxlint` because the wrapper cannot write fixes back yet.
+3. **MSW handler paths are written `*/api/members`, not `/api/members`.** A bare relative path
+   resolves against `document.baseURI`, which does not exist under Node, and the same handlers must
+   match in the browser, in Vitest and in Playwright.
+4. **MSW runs in production too.** `/demo` has no backend, so a dev-only mock would leave the deployed
+   page permanently erroring. `src/main.ts` must keep `await`ing `worker.start()` before mounting, or
+   the first query races the worker and gets a real 404.
+5. **`public/mockServiceWorker.js` is generated and committed.** Regenerate with
+   `pnpm exec msw init public --save` after an msw upgrade; never hand-edit it.
+6. **A new tsconfig must be added to `references` in `tsconfig.json`.** `vue-tsc --build` silently
+   skips projects that are not listed — that is how the e2e suite went unchecked for a while.
+7. **`auto-imports.d.ts`, `components.d.ts` and `src/typed-router.d.ts` are committed.** A fresh clone
+   must type-check before anything has been run. Commit the regenerated files with your change.
+8. **Deploy scripts are `cf:`-prefixed, and invoked as `pnpm run cf:deploy`.** Never rename them to a
+   bare `deploy`: `pnpm deploy` is a built-in pnpm command for workspace pruning and would shadow the
+   script silently.
+9. **`@playwright/test` is pinned exactly, no caret.** The NixOS dev shell points
+   `PLAYWRIGHT_BROWSERS_PATH` at the nixpkgs browser bundle, whose revisions are matched per
+   Playwright release. Bump it only together with `pkgs.playwright-driver` in `devenv.nix`.
+10. **`vueDevTools` and `TurboConsole` are skipped under Vitest** in `vite.config.ts`. They hold
+    handles open that add a 10s "close timed out" stall to every `vitest run`.
+11. **Markdown headings have no `id`s.** No anchor plugin is configured, so `#section` deep links into
+    `/docs` will not scroll. Link to the page and name the section in the link text.
+
+## Commits and pull requests
+
+Commits are **[conventional commits](https://www.conventionalcommits.org)** — the changelog is
+generated from them by changelogen, and a non-conventional message is **skipped entirely**, so the
+change will not appear in any release.
+
+- `feat:` bumps the minor, `fix:`/`perf:`/`refactor:`/`docs:`/`build:` the patch, `!` or
+  `BREAKING CHANGE:` the major.
+- `chore(deps): …` is dropped from the changelog unless breaking.
+- Run `pnpm check` and `pnpm test` before committing. `pre-commit` fixes and formats staged files;
+  `pre-push` runs the full lint + format + type-check.
+- `main` is protected — land changes through a pull request.
+
+Do not bump the version or edit `CHANGELOG.md` by hand; releases are cut by changelogen (`pnpm release`
+locally, or the **Release** workflow, which opens a `release/vX.Y.Z` PR to be merged). Nothing is ever
+published to npm — `package.json` is `private: true`.
+
+## Deployment
+
+`wrangler.jsonc` is an assets-only Cloudflare Worker: no `main`, so no Worker code runs and Cloudflare
+serves `dist/` from its edge. `not_found_handling: "single-page-application"` is load-bearing —
+vue-router is in history mode, so without it a hard refresh on `/demo` returns a 404. Real files still
+win, which is what keeps `/mockServiceWorker.js` working.
+
+CI deploys every push to `main` from the `deploy` job in `.github/workflows/ci.yml`, gated behind
+`needs: ci`. A fork without `CLOUDFLARE_API_TOKEN` logs a notice and exits green rather than turning
+`main` red — keep that behaviour if you touch the workflow.
+
+Adding a `"main"` entry to `wrangler.jsonc` turns this into a full Worker with the same assets in front
+of it, so a server-side API route later is a config change rather than a migration.
+
+## Further reading
+
+`docs/reference.md` (the [/docs](https://vue-starter.raz.wtf/docs) page) explains the reasoning behind
+all of the above, plus the bundle costs of Reka UI and MSW, the full lint coverage ledger, and the
+release and Cloudflare setup in detail.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -6,141 +6,89 @@ Requires **Node 26** and **pnpm 11**.
 ```sh
 npx degit RazorSiM/vue-starter
 pnpm install
+pnpm dev
 ```
+
+A modern Vue 3 stack wired together and verified end to end: Vite 8, file-based routing, UnoCSS with
+the Tailwind-v4-aligned engine, accessible interaction primitives from Reka UI, and the Rust-based
+oxc toolchain for linting and formatting.
+
+This page is `README.md` itself, rendered as the homepage by
+[unplugin-vue-markdown](https://github.com/unplugin/unplugin-vue-markdown). Four other pages ship
+with the template:
+
+| page                                                | what it shows                                                        |
+| --------------------------------------------------- | -------------------------------------------------------------------- |
+| [/demo](https://vue-starter.raz.wtf/demo)           | one resource wired through every data library in the stack           |
+| [/layout](https://vue-starter.raz.wtf/layout)       | switching layouts at runtime, backed by the `useLayout()` composable |
+| [/changelog](https://vue-starter.raz.wtf/changelog) | `CHANGELOG.md`, rendered the same way as this page                   |
+| [/docs](https://vue-starter.raz.wtf/docs)           | the long-form reference: rationale, bundle costs, and the gotchas    |
+
+Working on this repo with a coding agent? [`AGENTS.md`](AGENTS.md) is the runbook — commands,
+conventions, and the traps that are not obvious from reading the code.
 
 ## What's Included
 
-A modern Vue 3 stack wired together and verified end to end: Vite 8, file-based routing,
-UnoCSS with the Tailwind-v4-aligned engine, accessible interaction primitives from Reka UI, and the
-Rust-based oxc toolchain for linting and formatting.
+### Framework and build
 
-### Features
+| package                                        | what it does                                                                      |
+| ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| **[Vue 3.5](https://vuejs.org)**               | the progressive JavaScript framework                                              |
+| **[Vite 8](https://vite.dev)**                 | Rolldown bundler with Oxc-powered transforms                                      |
+| **[Vue Router 5](https://router.vuejs.org)**   | file-based routing, fully typed — the plugin now ships inside `vue-router` itself |
+| **[TypeScript 6](https://typescriptlang.org)** | full `.vue` support through `vue-tsc`                                             |
+| **[Unhead 3](https://unhead.unjs.io)**         | SEO and page metadata                                                             |
 
-- **[Vue 3](https://vuejs.org)** (3.5) — the progressive JavaScript framework.
-- **[Vite 8](https://vite.dev)** — Rolldown bundler with Oxc-powered transforms.
-- **[Vue Router 5](https://router.vuejs.org)** with **file-based routing**. Pages live in
-  `src/pages/`, per-route metadata is declared with the `definePage()` macro, and fully typed
-  routes are generated into `src/typed-router.d.ts`. The file conventions:
+Pages live in `src/pages/`, per-route metadata is declared with the `definePage()` macro, and typed
+routes are generated into `src/typed-router.d.ts`. The full filename → URL table is under _Routing_
+in [the docs](https://vue-starter.raz.wtf/docs).
 
-  | file               | route                                              |
-  | ------------------ | -------------------------------------------------- |
-  | `index.vue`        | `/`                                                |
-  | `layout.vue`       | `/layout`                                          |
-  | `[id].vue`         | `/:id`                                             |
-  | `[[id]].vue`       | `/:id?` (optional param)                           |
-  | `[...path].vue`    | `/:path(.*)` (404 catch-all)                       |
-  | `(group)/foo.vue`  | `/foo` (folder stripped from the URL)              |
-  | `users.create.vue` | `/users/create` (dot nesting, no nested component) |
+### Data and state
 
-  The route-building plugin now ships inside `vue-router` itself — `unplugin-vue-router` is no
-  longer a separate dependency.
+| package                                                                                | what it does                                                     |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| **[TanStack Query 5](https://tanstack.com/query/latest/docs/framework/vue/overview)**  | server state: caching, background refetching, invalidation       |
+| **[TanStack Form 1](https://tanstack.com/form/latest/docs/framework/vue/quick-start)** | form state and validation, fed directly by a zod schema          |
+| **[TanStack Table 8](https://tanstack.com/table/latest/docs/framework/vue/vue-table)** | headless sorting and filtering — you write the markup            |
+| **[zod 4](https://zod.dev)**                                                           | one schema per resource: validates, parses, and infers the types |
+| **[Pinia 4](https://pinia.vuejs.org)**                                                 | client state, for what Query deliberately does not own           |
+| **[MSW 2](https://mswjs.io)**                                                          | the API the demo talks to, in every environment                  |
+| **[VueUse 14](https://vueuse.org)**                                                    | essential composition utilities                                  |
 
-- **[TanStack Query 5](https://tanstack.com/query/latest/docs/framework/vue/overview)** — server
-  state: caching, background refetching, loading and error states, and cache invalidation after a
-  mutation. Installed via `VueQueryPlugin` in `src/main.ts` with a 30s default `staleTime`.
-- **[TanStack Form 1](https://tanstack.com/form/latest/docs/framework/vue/quick-start)** — form
-  state and validation, fed directly by a zod schema. zod 4 implements
-  [Standard Schema](https://standardschema.dev), so there is no resolver package in between.
-- **[TanStack Table 8](https://tanstack.com/table/latest/docs/framework/vue/vue-table)** — headless
-  sorting and filtering. You write the markup; it owns the row model.
-- **[zod 4](https://zod.dev)** — one schema per resource in `src/schemas/`, used three ways: it
-  validates the form, parses the API response at the network boundary, and infers the TypeScript
-  types. A field cannot drift between the three.
-- **[MSW 2](https://mswjs.io)** — the API the demo talks to. Handlers live in
-  `src/mocks/handlers.ts` and serve all three environments: the browser (via a service worker), the
-  unit tests (via `setupServer`) and the Playwright run.
-- **[Pinia 4](https://pinia.vuejs.org)** — client state, for the things Query deliberately does not
-  own: no server, no cache, nothing to invalidate. The `/demo` page puts the two side by side.
-- **[VueUse 14](https://vueuse.org)** — essential composition utilities.
-- **[Unhead 3](https://unhead.unjs.io)** — SEO and page metadata.
-- **[Reka UI 2](https://reka-ui.com)** — unstyled, accessible component primitives. It ships the
-  behaviour that is tedious to write and easy to get subtly wrong — roving focus, focus trapping and
-  restoration, ARIA wiring, Escape handling — and ships no CSS at all, so UnoCSS still owns every
-  pixel. It is used in four places, each one replacing markup that was actively misleading to a
-  screen reader:
+### UI and styling
 
-  | primitive     | where                                                                            | what it replaced                                                                      |
-  | ------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-  | `RadioGroup`  | the role field in `Demo/MemberForm.vue`, the layout picker in `pages/layout.vue` | `aria-pressed` toggle buttons — a one-of-N choice announced as N independent switches |
-  | `AlertDialog` | the row remove confirmation in `Demo/MemberTable.vue`                            | an immediate, unconfirmed delete                                                      |
-  | `Tooltip`     | the `src/pages/…` hint in `TopNav.vue`                                           | a `title` attribute, which never opens on keyboard focus                              |
-  | `Primitive`   | `Ui/Button`                                                                      | a `tag` prop that was declared and then ignored                                       |
+| package                                | what it does                                                             |
+| -------------------------------------- | ------------------------------------------------------------------------ |
+| **[UnoCSS 66](https://unocss.dev)**    | instant atomic CSS, on the Tailwind-v4-aligned `preset-wind4`            |
+| **[Reka UI 2](https://reka-ui.com)**   | unstyled, accessible primitives — behaviour without a single line of CSS |
+| **[Lucide](https://lucide.dev)** icons | pure-CSS icons as plain classes: `<div class="i-lucide-house" />`        |
+| **[Shiki](https://shiki.style)**       | dual-theme Markdown syntax highlighting                                  |
 
-  Three things follow from using it:
+Reka UI supplies the parts that are tedious to write and easy to get subtly wrong — roving focus,
+focus trapping, ARIA wiring, Escape handling. It is used in exactly four places, each replacing
+markup that was actively misleading to a screen reader; the _Reka UI_ section of
+[the docs](https://vue-starter.raz.wtf/docs) has the inventory and the bundle cost.
 
-  - **Parts auto-import** via `RekaResolver()` in `vite.config.ts`, so an alert dialog costs eight
-    tags and zero import lines. Unused primitives are still tree-shaken.
-  - **Style with `data-[state=…]`**, not with a bound class expression. The primitive already tracks
-    checked/open/closed and exposes it as an attribute, so
-    `data-[state=checked]:border-indigo-500` replaces a ternary over your own state.
-  - **It does not replace native elements that were already correct.** The name and email fields are
-    still `<input>` with `<label for>`, and "simulate a 500" is still a real checkbox. Reaching for a
-    primitive where the platform already gives you the semantics buys nothing but JavaScript.
+**Multi-layout support** needs no extra dependency: `src/App.vue` resolves layouts with an
+`import.meta.glob` lookup keyed by `route.meta.layout`, so adding `src/layouts/Foo.vue` is all it
+takes.
 
-  **It costs ~47 KB gzipped across all chunks, ~37 KB of it on first paint.** The tooltip is the
-  expensive part: it lives in the header, so every page pulls in the popper and focus-management
-  code that `AlertDialog` also shares. If that trade is wrong for your app, deleting the
-  `TooltipRoot` wrapper in `src/components/TopNav.vue` is the single biggest saving, and an
-  `aria-describedby` pointing at a `sr-only` span keeps the screen-reader behaviour for no
-  JavaScript — you just lose the hint for sighted mouse users. The `RadioGroup` and `AlertDialog`
-  conversions are close to free by comparison (~5 KB of route chunk each).
+### Tooling
 
-  Reka UI is deliberately unstyled. If you want a styled layer on top of exactly these primitives,
-  [shadcn-vue](https://www.shadcn-vue.com) is Reka UI plus a component library.
-
-- **[UnoCSS 66](https://unocss.dev)** — instant atomic CSS.
-  - **[@unocss/preset-wind4](https://unocss.dev/presets/wind4)**: the Tailwind-v4-aligned engine
-    (oklch colours, CSS-variable theme). Its reset is built in via `preflights.reset`, so no
-    separate `@unocss/reset` package is needed.
-  - **[@unocss/preset-icons](https://unocss.dev/presets/icons)**: pure-CSS icons.
-  - **[@unocss/preset-web-fonts](https://unocss.dev/presets/web-fonts)**: Inter + Fira Code.
-  - **[@unocss/transformer-variant-group](https://unocss.dev/transformers/variant-group)**: write
-    `dark:(bg-gray-900 text-gray-50)` instead of repeating the variant.
-- **Icons: [Lucide](https://lucide.dev)** via `@iconify-json/lucide` — use them as plain classes,
-  e.g. `<div class="i-lucide-house" />`. Only the Lucide collection is installed (574 KB) rather
-  than the full `@iconify/json` (439 MB). Browse the set at [icones.js.org](https://icones.js.org).
-- **Multi-layout support** — `src/App.vue` resolves layouts with an `import.meta.glob` lookup keyed
-  by `route.meta.layout`, so adding `src/layouts/Foo.vue` is all it takes. No extra dependency.
-  `DefaultLayout` supplies the app chrome; `EmptyLayout` is deliberately bare. The
-  [/layout](https://vue-starter.raz.wtf/layout) page is a live demo — switch layouts and
-  watch the header appear and disappear, backed by the `useLayout()` composable.
-- **Markdown Vue components** via
-  [unplugin-vue-markdown](https://github.com/unplugin/unplugin-vue-markdown) — this README is
-  itself rendered as the homepage.
-- **[Shiki](https://shiki.style)** — dual-theme Markdown syntax highlighting.
-
-### Development Experience
-
-- **TypeScript 6** with full `.vue` support through `vue-tsc`. `tsconfig.json` is a solution file
-  referencing three projects, and `pnpm type-check` builds all of them: `tsconfig.app.json`
-  (`src/`, including unit specs), `tsconfig.node.json` (the root `*.config.ts` files) and
-  `e2e/tsconfig.json` (the Playwright suite). A project missing from `references` is silently
-  skipped by `vue-tsc --build`, which is exactly how the e2e suite went unchecked for a while.
-- **[oxlint](https://oxc.rs/docs/guide/usage/linter) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter)**
-  — the Rust-based oxc toolchain, configured in `.oxlintrc.json` and `.oxfmtrc.json`. No ESLint,
-  no Prettier. Vue `<template>` rules come from
-  [Vize](https://github.com/ubugeeei-prod/vize) via `oxlint-plugin-vize` — see
-  [Linting & formatting](#linting--formatting).
-- **[Lefthook 2](https://github.com/evilmartians/lefthook)** — git hooks. `pre-commit` lints and
-  formats staged files; `pre-push` runs the full lint + format + type-check.
-- **[changelogen](https://github.com/unjs/changelogen)** — version bump, `CHANGELOG.md` and the
-  GitHub release, all derived from conventional commits. See [Releases](#releases).
-- **[devenv](https://devenv.sh)** — a reproducible Nix dev shell pinning Node, pnpm and the
-  Playwright browsers. Entirely optional; see [Requirements](#requirements).
-- **Auto-imports** — [unplugin-auto-import](https://github.com/unplugin/unplugin-auto-import) for
-  composables and [unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components)
-  for components, the latter with Reka UI's resolver registered so its primitives resolve by name
-  too. Both write their declarations to the repo root (`auto-imports.d.ts`, `components.d.ts`) and
-  both files are committed, so a fresh clone type-checks before anything has been run.
-- **[unplugin-turbo-console](https://github.com/unplugin/unplugin-turbo-console)** and
-  **[vite-plugin-vue-devtools](https://github.com/vuejs/devtools-next)** for debugging.
-- **VS Code integration** — format-on-save and `source.fixAll.oxc` via the `oxc.oxc-vscode`
-  extension. The ESLint and Prettier extensions are listed under `unwantedRecommendations`.
+| tool                                                                                                      | what it does                                                               |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **[oxlint](https://oxc.rs/docs/guide/usage/linter) + [oxfmt](https://oxc.rs/docs/guide/usage/formatter)** | the Rust-based oxc toolchain. No ESLint, no Prettier                       |
+| **[Vize](https://github.com/ubugeeei-prod/vize)**                                                         | Vue `<template>` rules, bridged into oxlint as `vize/*`                    |
+| **[Vitest 4](https://vitest.dev) + [Playwright](https://playwright.dev)**                                 | unit and e2e tests, both backed by the same MSW handlers                   |
+| **[Lefthook 2](https://github.com/evilmartians/lefthook)**                                                | git hooks: `pre-commit` fixes staged files, `pre-push` runs the full check |
+| **[changelogen](https://github.com/unjs/changelogen)**                                                    | version bump, changelog and GitHub release from conventional commits       |
+| **[devenv](https://devenv.sh)**                                                                           | an optional reproducible Nix shell pinning Node, pnpm and the browsers     |
+| **auto-imports**                                                                                          | composables and components resolve by name; declarations are committed     |
 
 ## The data layer
 
-[/demo](https://vue-starter.raz.wtf/demo) is one resource — a members list — wired
-through every data library in the stack, rather than three disconnected toys:
+[/demo](https://vue-starter.raz.wtf/demo) is one resource — a members list — wired through every
+data library in the stack, rather than three disconnected toys:
 
 ```
 src/schemas/member.ts     zod schemas + inferred types      (the contract)
@@ -151,130 +99,23 @@ src/composables/          useMembers(): query + mutations   (the state)
 src/components/Demo/      form, table, panel                (the UI)
 ```
 
-Four things worth knowing:
-
-1. **zod parses at the boundary, it does not cast.** `src/api/members.ts` runs
-   `memberListSchema.parse()` on every response. A backend that renames a field fails loudly in one
-   file, instead of surfacing as `undefined` three components away.
-2. **Mutations invalidate, they do not patch the cache.** `id`, `commits` and `joinedAt` are the
-   server's to assign, so `useMembers()` invalidates the `['members']` key and refetches rather than
-   guessing what the server did.
-3. **The "simulate a 500" toggle is part of the query key**, not just the fetcher. Flipping it is a
-   different resource as far as the cache is concerned, so both results stay cached and toggling
-   back is instant. `retry` is off so the error state is visible immediately — delete that line for
-   the sensible production default.
-4. **Components never see a query key or a `fetch`.** `MemberForm` emits a validated value and
-   knows nothing about the API, which is why it can be unit-tested without a server at all.
-
-### MSW
-
-The mock runs in **every** environment, including the production build — `/demo` has no backend, so
-a dev-only mock would leave the deployed page showing a permanent error. `src/main.ts` awaits
-`worker.start()` before mounting, or the first query would race the worker and get a real 404.
-
-- `public/mockServiceWorker.js` is generated (`pnpm exec msw init public --save`) and **committed**.
-  The `msw.workerDirectory` field in `package.json` plus the `allowBuilds: msw` entry in
-  `pnpm-workspace.yaml` let msw's postinstall refresh it on upgrade; without that it silently drifts
-  out of sync with the installed version.
-- Handler paths are written `*/api/members`, not `/api/members`. A bare relative path resolves
-  against `document.baseURI`, which does not exist under Node — the same handlers have to match in
-  the browser, in vitest and in Playwright.
-- **It costs ~158 KB gzipped**, loaded on first paint because the mount awaits it. That is the price
-  of a demo that works offline and on a static host. To pay it only in development, guard the call
-  in `src/main.ts` with `import.meta.env.DEV`; to remove mocking entirely, delete `startMockApi()`
-  and `src/mocks/`, and point `src/api/members.ts` at a real origin.
-
-## Linting & formatting
-
-The honest ledger of what is and isn't covered:
-
-| Target                                       | Linted                                                                               | Formatted |
-| -------------------------------------------- | ------------------------------------------------------------------------------------ | --------- |
-| `.ts` / `.js`                                | eslint core, typescript, unicorn, oxc, import, promise, node — plus type-aware rules | yes       |
-| `.vue` `<script setup>`                      | full JS/TS rules + oxlint's native `vue` plugin                                      | yes       |
-| `.vue` `<template>`                          | `vize/*` rules via `oxlint-plugin-vize`                                              | yes       |
-| `*.spec.ts`                                  | oxlint's native `vitest` plugin                                                      | yes       |
-| `e2e/*.spec.ts`                              | oxlint core rules                                                                    | yes       |
-| `.md` / `.json` / `.yaml` / `.css` / `.html` | no                                                                                   | yes       |
-
-Vue template linting comes from [Vize](https://github.com/ubugeeei-prod/vize), a Rust Vue toolchain,
-bridged into oxlint as `vize/*` rules. `eslint-plugin-vue` cannot be ported to oxlint — it depends on
-`vue-eslint-parser` and its own AST — so this is the route to `v-for` key checks, `v-html` warnings,
-unused-component detection and a11y rules without bringing ESLint back.
-
-Five things worth knowing about the setup:
-
-1. **`pnpm lint` runs `oxlint-vize`, not `oxlint`.** Plain `oxlint` silently skips `.vue` files that
-   have no `<script>` block — two of this template's components are scriptless, so 25% of the
-   components would appear linted while not being linted at all. The wrapper works around it.
-2. **`pnpm lint:fix` stays on plain `oxlint`.** The wrapper cannot write fixes back yet
-   ("fixes are not applied back to original files yet"), so autofix uses oxlint directly.
-3. **`node_modules` must NOT be added to `ignorePatterns` in `.oxlintrc.json`.** The wrapper stages
-   temporary copies of scriptless SFCs under `node_modules/.vize/`, and ignoring that path silently
-   disables every template rule while still exiting 0. oxlint already skips `node_modules` by
-   default and respects `.gitignore`, so the entry is unnecessary as well as harmful.
-4. **`settings.vize.preset` is `"incremental"`.** Every other preset gates rules by bundle
-   membership and will keep explicitly-listed rules quiet. `incremental` runs exactly the
-   `vize/*` rules enumerated in `.oxlintrc.json` and nothing else.
-5. **`pnpm lint` passes `--type-aware`**, which turns on rules needing type information —
-   `no-floating-promises`, `await-thenable`, `no-misused-promises` and ~20 more. This requires the
-   `oxlint-tsgolint` package (a native binary, exact-pinned) and costs about 0.2s here. Note it
-   covers `.ts`/`.js` only, not `.vue` SFCs. The pre-commit hook deliberately runs plain `oxlint`
-   for speed; type-aware runs on pre-push and in CI.
-
-Two gaps remain:
-
-- **`no-unused-vars` is still inert inside `<script setup>`** — oxlint cannot see template usage, so
-  it cannot distinguish a template-consumed ref from a dead one (tracked upstream in
-  [oxc#15761](https://github.com/oxc-project/oxc/issues/15761)). `noUnusedLocals` and
-  `noUnusedParameters` in `tsconfig.app.json` mean `pnpm type-check` catches it instead.
-- **No UnoCSS class ordering or validation.** `@unocss/eslint-plugin` needs a Vue template AST.
-  `presetIcons({ warn: true })` at least surfaces typo'd icon names at build time.
-
-`oxlint-plugin-vize` is pre-1.0 and ships a native binary requiring **glibc 2.39+** (Ubuntu 24.04+,
-Debian 13+). To remove it: delete the `jsPlugins`, `settings` and `vize/*` rule entries from
-`.oxlintrc.json`, drop the `oxlint-vize` job from `lefthook.yaml`, and set `"lint": "oxlint ."`.
-Everything else keeps working.
+The four rules that hold it together — zod parses at the boundary rather than casting, mutations
+invalidate rather than patch the cache, the error toggle is part of the query key, and components
+never see a query key or a `fetch` — are explained under _The data layer_ in
+[the docs](https://vue-starter.raz.wtf/docs).
 
 ## Requirements
 
-- **Node 26** (see `.nvmrc`) and **pnpm 11**.
-- Note that **Node 26 is the Current channel, not LTS** — it enters LTS in October 2026, and Node 24
-  "Krypton" is today's Active LTS. `engines.node` is set to `>=26.0.0`, which pnpm enforces as a
-  hard install failure. If you fork this for production on an LTS line, relax that field.
+**Node 26** (see `.nvmrc`) and **pnpm 11**. Note that Node 26 is the Current channel, not LTS — it
+enters LTS in October 2026. `engines.node` is `>=26.0.0`, which pnpm enforces as a hard install
+failure, so relax that field if you fork this for production on an LTS line.
 
-### Optional: reproducible shell with Nix
+With [devenv](https://devenv.sh) and [direnv](https://direnv.net) installed, `direnv allow` gets you
+a shell with Node, pnpm and the Playwright browsers pinned. It is entirely optional: `devenv.nix`,
+`devenv.yaml` and `.envrc` are inert without Nix, and `pnpm install` works exactly as normal. See
+_Requirements_ in [the docs](https://vue-starter.raz.wtf/docs) for the two NixOS-specific caveats.
 
-If you have [devenv](https://devenv.sh) and [direnv](https://direnv.net):
-
-```sh
-direnv allow    # or: devenv shell
-```
-
-This pins Node 26.5.0, pnpm 11.15.0 and the Playwright browsers from nixpkgs. `devenv.nix`,
-`devenv.yaml` and `.envrc` are inert for everyone else — without Nix installed, `pnpm install`
-works exactly as normal.
-
-Two Nix-specific notes:
-
-- Playwright's own downloaded browsers are linked against FHS paths that don't exist on NixOS, so
-  the shell points `PLAYWRIGHT_BROWSERS_PATH` at the nixpkgs bundle instead. Browser revisions are
-  matched per Playwright release, which is why **`@playwright/test` is pinned exactly** (no caret)
-  to whatever `pkgs.playwright-driver` provides. `enterShell` warns if the two drift apart. On CI
-  neither variable is set and `playwright install --with-deps` behaves normally.
-- Node 26 no longer bundles corepack, so pnpm comes from nixpkgs. Keep `packageManager` in
-  `package.json` aligned with it, or pnpm's own version self-check will download a different pnpm
-  inside the shell.
-
-## Recommended IDE Setup
-
-- **[VS Code](https://code.visualstudio.com)**
-- **[Vue - Official (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.volar)**
-- **[oxc](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode)**
-
-**Disable the ESLint and Prettier extensions for this workspace** — they will double-format.
-
-## Project Setup
+## Scripts
 
 ```sh
 pnpm install       # installs deps and git hooks (prepare -> lefthook install)
@@ -284,7 +125,7 @@ pnpm preview       # preview the production build on :4173
 pnpm test          # unit tests (vitest run)
 pnpm test:watch    # unit tests in watch mode
 pnpm test:e2e      # playwright (run `pnpm exec playwright install` once first)
-pnpm lint          # oxlint
+pnpm lint          # oxlint + vue template rules, type-aware
 pnpm lint:fix      # oxlint --fix
 pnpm format        # oxfmt
 pnpm check         # lint + format:check + type-check
@@ -292,138 +133,39 @@ pnpm changelog     # preview the unreleased changelog (writes nothing)
 pnpm release       # bump + changelog + commit + tag + push + GitHub release
 ```
 
-End-to-end tests run against the Vite dev server locally for a fast feedback loop. CI builds first
-and tests the preview server:
-
-```sh
-pnpm build
-CI=1 pnpm test:e2e
-```
-
-Both layers are backed by the same MSW handlers, from opposite sides. The unit tests start
-`setupServer` in `src/test/setup.ts` with `onUnhandledRequest: 'error'` — a request nobody mocked is
-a bug in the test, not something to quietly let through — and reset the in-memory db between tests,
-since it is module state that would otherwise leak from one test's POST into the next test's GET.
-The Playwright suite drives the real service worker in a real browser, which is what notices when
-`public/mockServiceWorker.js` goes missing or stale.
-
-## Releases
-
-Releases are cut with [changelogen](https://github.com/unjs/changelogen) from
-[conventional commits](https://www.conventionalcommits.org). Configuration lives in
-`changelog.config.ts`, and it is deliberately almost empty — changelogen's defaults already
-produce the format this `CHANGELOG.md` has used since v3.0.0.
-
-```sh
-pnpm changelog     # what would the next entry look like? Prints to stdout, writes nothing.
-pnpm release       # cut it
-```
-
-`pnpm release` runs `changelogen --release --clean --push`, which:
-
-1. refuses to start if the working tree is dirty (`--clean`);
-2. derives the next version from the commits since the last tag — `feat:` bumps the minor,
-   `fix:`/`perf:`/`refactor:`/`docs:`/`build:` the patch, a `!` or `BREAKING CHANGE:` the major —
-   and writes it to `package.json`;
-3. prepends the new section to `CHANGELOG.md`, which the
-   [/changelog](https://vue-starter.raz.wtf/changelog) page renders as-is;
-4. commits `chore(release): vX.Y.Z`, creates an annotated `vX.Y.Z` tag, and pushes both
-   (`git push --follow-tags`);
-5. creates the matching GitHub release.
-
-Override the computed bump by appending the level: `pnpm release --major`.
-
-Step 5 needs a GitHub token, looked up in this order: `CHANGELOGEN_TOKENS_GITHUB`, `GITHUB_TOKEN`,
-`GH_TOKEN`, then the [`gh` CLI](https://cli.github.com) config. With none of them, the first four
-steps still happen and changelogen prints a pre-filled "create release" URL to open by hand.
-
-The push in step 4 goes through lefthook's `pre-push` hook, so lint, format and type-check run
-before anything reaches the remote. Nothing is ever published to npm — `package.json` is
-`private: true`.
-
-### Releasing from GitHub
-
-`.github/workflows/release.yml` reaches the same end state on a runner, with no token needed
-locally. It takes two steps rather than one, because a protected `main` accepts changes only
-through a pull request and the built-in `GITHUB_TOKEN` cannot bypass that:
-
-1. **Actions → Release → Run workflow**, with a `bump` input of `auto` (default), `patch`,
-   `minor` or `major`. This runs `pnpm check` and the unit tests, does steps 1–3 above, and opens
-   a `release/vX.Y.Z` pull request containing just the `CHANGELOG.md` and `package.json` diff.
-2. **Merge that PR.** The push to `main` triggers the workflow's `tag` job, which creates the
-   annotated `vX.Y.Z` tag and the GitHub release.
-
-The `tag` job recognises a release by the pair a release commit always leaves behind — a version
-in `package.json` with no tag yet, plus a matching `## vX.Y.Z` heading in `CHANGELOG.md` — so
-ordinary commits that touch `package.json` pass straight through it.
-
-Two things to know before tightening `main`'s protection further: a PR opened with `GITHUB_TOKEN`
-does not trigger `on: pull_request`, so CI does not run on the release PR (the workflow's own
-check/test steps are the gate instead), and adding **required status checks** would therefore
-deadlock every release PR unless the PR is opened with a PAT or GitHub App token instead.
-
-Two conventions worth keeping, since the changelog is only as good as the commits:
-
-- **`chore(deps): …` commits are dropped** from the changelog by changelogen unless they are
-  breaking. Dependabot/Renovate noise stays out on its own.
-- **Non-conventional commit messages are skipped entirely.** A change committed as
-  `fixed the thing` will not appear in any release.
-
 ## Deployment
 
 Deployed to **Cloudflare Workers** as static assets, at
-[vue-starter.raz.wtf](https://vue-starter.raz.wtf).
+[vue-starter.raz.wtf](https://vue-starter.raz.wtf). `wrangler.jsonc` is an assets-only Worker — no
+`main`, so no Worker code runs and Cloudflare serves `dist/` from its edge, which is
+[free and unlimited](https://developers.cloudflare.com/workers/platform/pricing/) on both plans.
 
-`wrangler.jsonc` is an assets-only Worker: no `main`, so no Worker code runs and Cloudflare serves
-`dist/` from its edge. Two details carry weight:
-
-- **`not_found_handling: "single-page-application"`.** vue-router runs in history mode, so `/demo`
-  matches no file on disk — without this, a hard refresh anywhere but `/` returns Cloudflare's 404.
-  Real files still take precedence, which is what keeps `/mockServiceWorker.js` working; a fallback
-  to `index.html` there would silently break the demo page.
-- **Worker, not Pages.** Pages is in maintenance mode and cannot grow server-side code. Adding a
-  `"main"` entry to `wrangler.jsonc` turns this into a full Worker with the same assets in front of
-  it, so an API route later is a config change rather than a migration.
-- **It is free.** [Requests to static assets are free and unlimited](https://developers.cloudflare.com/workers/platform/pricing/)
-  on both plans, and an assets-only Worker serves nothing else — so the free plan's 100,000
-  requests/day applies to Worker invocations you do not have. Free-plan asset limits are 20,000 files
-  per version and 25 MiB per file; this build ships 13 files. Cost-identical to Pages.
-
-The site answers on a **Custom Domain** (`routes` with `custom_domain: true`), which means Cloudflare
-creates the DNS record and manages the certificate — there is nothing to add by hand, but the zone
-must be in the same account as the Worker. `workers_dev` is off since the real domain covers it, and
-`preview_urls` is then set back to `true` explicitly: since wrangler 4.44 preview URLs default to
-matching `workers_dev`, so disabling the workers.dev route would otherwise take `cf:preview` with it.
-
-CI deploys on every push to `main`, from the `deploy` job in `.github/workflows/ci.yml`. It is gated
-behind `needs: ci`, so only a commit that passed lint, types, unit tests and e2e ever ships. Two
-repository secrets are required:
-
-| secret                  | where to get it                                                              |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`  | Cloudflare dashboard → My Profile → API Tokens → **Edit Cloudflare Workers** |
-| `CLOUDFLARE_ACCOUNT_ID` | Workers & Pages → Account details, or `wrangler whoami`                      |
-
-They are secrets rather than values in the workflow on purpose: this is a template, and a fork
-should not inherit someone else's account ID. With no token set the deploy job logs a notice and
-exits green, so forks do not get a red `main`.
-
-The token needs zone access, not just account access — attaching a Custom Domain writes a DNS record.
-The **Edit Cloudflare Workers** template covers it (`Workers Scripts:Edit`, `Workers Routes:Edit`,
-`Zone:Read`, `DNS:Edit`). A token hand-scoped to account permissions only will deploy the Worker and
-then fail on the route.
-
-To deploy by hand:
+CI deploys on every push to `main`, gated behind the `ci` job, so only a commit that passed lint,
+types, unit tests and e2e ever ships. A fork without Cloudflare secrets logs a notice and exits
+green rather than turning `main` red.
 
 ```sh
-pnpm exec wrangler login
 pnpm run cf:deploy    # build + wrangler deploy
 pnpm run cf:preview   # build + wrangler versions upload — a preview URL, production untouched
 ```
 
 Note the `pnpm run`: `pnpm deploy` is a built-in pnpm command for workspace pruning and will _not_
-run this script.
+run this script. [The docs](https://vue-starter.raz.wtf/docs) cover the SPA fallback, the custom
+domain, and the two required repository secrets.
 
-## Customize Configuration
+## Recommended IDE Setup
 
-See the [Vite Configuration Reference](https://vite.dev/config/).
+[VS Code](https://code.visualstudio.com) with
+[Vue - Official (Volar)](https://marketplace.visualstudio.com/items?itemName=Vue.volar) and
+[oxc](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode). Both are in
+`.vscode/extensions.json`, along with format-on-save and `source.fixAll.oxc`.
+
+**Disable the ESLint and Prettier extensions for this workspace** — they will double-format. They
+are listed under `unwantedRecommendations` for that reason.
+
+## Further reading
+
+- **[/docs](https://vue-starter.raz.wtf/docs)** — the long-form reference. Why each choice was made,
+  what it costs in kilobytes, and the sharp edges in the lint, mock and release setup.
+- **[`AGENTS.md`](AGENTS.md)** — the same ground as instructions for a coding agent.
+- **[`CHANGELOG.md`](https://vue-starter.raz.wtf/changelog)** — what changed, and when.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,409 @@
+# Reference
+
+The long-form half of the [README](https://vue-starter.raz.wtf/): why each piece is here, what it
+costs, and the sharp edges worth knowing before you change something. If you are a coding agent, read
+[`AGENTS.md`](https://github.com/RazorSiM/vue-starter/blob/main/AGENTS.md) instead — it is the same
+ground as instructions rather than prose.
+
+## Routing
+
+Pages live in `src/pages/`, per-route metadata is declared with the `definePage()` macro, and fully
+typed routes are generated into `src/typed-router.d.ts`. The file conventions:
+
+| file               | route                                              |
+| ------------------ | -------------------------------------------------- |
+| `index.vue`        | `/`                                                |
+| `layout.vue`       | `/layout`                                          |
+| `[id].vue`         | `/:id`                                             |
+| `[[id]].vue`       | `/:id?` (optional param)                           |
+| `[...path].vue`    | `/:path(.*)` (404 catch-all)                       |
+| `(group)/foo.vue`  | `/foo` (folder stripped from the URL)              |
+| `users.create.vue` | `/users/create` (dot nesting, no nested component) |
+
+The route-building plugin now ships inside `vue-router` itself — `unplugin-vue-router` is no longer a
+separate dependency. It is registered with `extensions: ['.vue']`, so a stray Markdown file under
+`src/pages/` does not silently become a route.
+
+### Multi-layout support
+
+`src/App.vue` resolves layouts with an `import.meta.glob` lookup keyed by `route.meta.layout`, so
+adding `src/layouts/Foo.vue` is all it takes. No extra dependency. `DefaultLayout` supplies the app
+chrome; `EmptyLayout` is deliberately bare. The [/layout](https://vue-starter.raz.wtf/layout) page is
+a live demo — switch layouts and watch the header appear and disappear, backed by the `useLayout()`
+composable.
+
+### Markdown pages
+
+[unplugin-vue-markdown](https://github.com/unplugin/unplugin-vue-markdown) compiles Markdown to Vue
+components, which is how three pages in this template work: the homepage renders `README.md`,
+[/changelog](https://vue-starter.raz.wtf/changelog) renders `CHANGELOG.md`, and this page renders
+`docs/reference.md`. [Shiki](https://shiki.style) provides dual-theme syntax highlighting inside
+them.
+
+No anchor plugin is configured, so headings do not get `id` attributes and `#section` deep links will
+not scroll. Adding [markdown-it-anchor](https://github.com/valeriangalliat/markdown-it-anchor) in
+`markdownSetup` is the fix if you want them.
+
+## The data layer
+
+[/demo](https://vue-starter.raz.wtf/demo) is one resource — a members list — wired through every data
+library in the stack, rather than three disconnected toys:
+
+```
+src/schemas/member.ts     zod schemas + inferred types      (the contract)
+src/mocks/handlers.ts     MSW handlers                      (the API)
+src/mocks/db.ts           seeded in-memory data
+src/api/members.ts        fetch + zod parse                 (the boundary)
+src/composables/          useMembers(): query + mutations   (the state)
+src/components/Demo/      form, table, panel                (the UI)
+```
+
+Four things worth knowing:
+
+1. **zod parses at the boundary, it does not cast.** `src/api/members.ts` runs
+   `memberListSchema.parse()` on every response. A backend that renames a field fails loudly in one
+   file, instead of surfacing as `undefined` three components away.
+2. **Mutations invalidate, they do not patch the cache.** `id`, `commits` and `joinedAt` are the
+   server's to assign, so `useMembers()` invalidates the `['members']` key and refetches rather than
+   guessing what the server did.
+3. **The "simulate a 500" toggle is part of the query key**, not just the fetcher. Flipping it is a
+   different resource as far as the cache is concerned, so both results stay cached and toggling back
+   is instant. `retry` is off so the error state is visible immediately — delete that line for the
+   sensible production default.
+4. **Components never see a query key or a `fetch`.** `MemberForm` emits a validated value and knows
+   nothing about the API, which is why it can be unit-tested without a server at all.
+
+### zod, once, three ways
+
+One schema per resource lives in `src/schemas/`, and it validates the form, parses the API response
+at the network boundary, and infers the TypeScript types. A field cannot drift between the three.
+zod 4 implements [Standard Schema](https://standardschema.dev), so TanStack Form consumes the schema
+directly and there is no resolver package in between.
+
+### Pinia, and where it stops
+
+[Pinia](https://pinia.vuejs.org) owns client state — the things Query deliberately does not: no
+server, no cache, nothing to invalidate. The [/demo](https://vue-starter.raz.wtf/demo) page puts the
+two side by side so the boundary is visible rather than asserted.
+
+## MSW
+
+The mock runs in **every** environment, including the production build — `/demo` has no backend, so a
+dev-only mock would leave the deployed page showing a permanent error. `src/main.ts` awaits
+`worker.start()` before mounting, or the first query would race the worker and get a real 404.
+
+- `public/mockServiceWorker.js` is generated (`pnpm exec msw init public --save`) and **committed**.
+  The `msw.workerDirectory` field in `package.json` plus the `allowBuilds: msw` entry in
+  `pnpm-workspace.yaml` let msw's postinstall refresh it on upgrade; without that it silently drifts
+  out of sync with the installed version.
+- Handler paths are written `*/api/members`, not `/api/members`. A bare relative path resolves
+  against `document.baseURI`, which does not exist under Node — the same handlers have to match in
+  the browser, in vitest and in Playwright.
+- **It costs ~158 KB gzipped**, loaded on first paint because the mount awaits it. That is the price
+  of a demo that works offline and on a static host. To pay it only in development, guard the call in
+  `src/main.ts` with `import.meta.env.DEV`; to remove mocking entirely, delete `startMockApi()` and
+  `src/mocks/`, and point `src/api/members.ts` at a real origin.
+
+## Reka UI
+
+[Reka UI](https://reka-ui.com) ships unstyled, accessible component primitives: the behaviour that is
+tedious to write and easy to get subtly wrong — roving focus, focus trapping and restoration, ARIA
+wiring, Escape handling — and no CSS at all, so UnoCSS still owns every pixel. It is used in four
+places, each one replacing markup that was actively misleading to a screen reader:
+
+| primitive     | where                                                                            | what it replaced                                                                      |
+| ------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `RadioGroup`  | the role field in `Demo/MemberForm.vue`, the layout picker in `pages/layout.vue` | `aria-pressed` toggle buttons — a one-of-N choice announced as N independent switches |
+| `AlertDialog` | the row remove confirmation in `Demo/MemberTable.vue`                            | an immediate, unconfirmed delete                                                      |
+| `Tooltip`     | the `src/pages/…` hint in `TopNav.vue`                                           | a `title` attribute, which never opens on keyboard focus                              |
+| `Primitive`   | `Ui/Button`                                                                      | a `tag` prop that was declared and then ignored                                       |
+
+Three things follow from using it:
+
+- **Parts auto-import** via `RekaResolver()` in `vite.config.ts`, so an alert dialog costs eight tags
+  and zero import lines. Unused primitives are still tree-shaken.
+- **Style with `data-[state=…]`**, not with a bound class expression. The primitive already tracks
+  checked/open/closed and exposes it as an attribute, so `data-[state=checked]:border-indigo-500`
+  replaces a ternary over your own state.
+- **It does not replace native elements that were already correct.** The name and email fields are
+  still `<input>` with `<label for>`, and "simulate a 500" is still a real checkbox. Reaching for a
+  primitive where the platform already gives you the semantics buys nothing but JavaScript.
+
+**It costs ~47 KB gzipped across all chunks, ~37 KB of it on first paint.** The tooltip is the
+expensive part: it lives in the header, so every page pulls in the popper and focus-management code
+that `AlertDialog` also shares. If that trade is wrong for your app, deleting the `TooltipRoot`
+wrapper in `src/components/TopNav.vue` is the single biggest saving, and an `aria-describedby`
+pointing at a `sr-only` span keeps the screen-reader behaviour for no JavaScript — you just lose the
+hint for sighted mouse users. The `RadioGroup` and `AlertDialog` conversions are close to free by
+comparison (~5 KB of route chunk each).
+
+Reka UI is deliberately unstyled. If you want a styled layer on top of exactly these primitives,
+[shadcn-vue](https://www.shadcn-vue.com) is Reka UI plus a component library.
+
+## Styling
+
+[UnoCSS](https://unocss.dev) provides instant atomic CSS, configured in `uno.config.ts`:
+
+- **[@unocss/preset-wind4](https://unocss.dev/presets/wind4)**: the Tailwind-v4-aligned engine (oklch
+  colours, CSS-variable theme). Its reset is built in via `preflights.reset`, so no separate
+  `@unocss/reset` package is needed.
+- **[@unocss/preset-icons](https://unocss.dev/presets/icons)**: pure-CSS icons.
+- **[@unocss/preset-typography](https://unocss.dev/presets/typography)**: the `prose` classes the
+  Markdown pages render into. Its inline-`<code>` backticks are switched off via `cssExtend`, since
+  the Markdown already reads as code without them.
+- **[@unocss/preset-web-fonts](https://unocss.dev/presets/web-fonts)**: Inter + Fira Code.
+- **[@unocss/transformer-variant-group](https://unocss.dev/transformers/variant-group)**: write
+  `dark:(bg-gray-900 text-gray-50)` instead of repeating the variant.
+
+Icons come from [Lucide](https://lucide.dev) via `@iconify-json/lucide` — use them as plain classes,
+e.g. `<div class="i-lucide-house" />`. Only the Lucide collection is installed (574 KB) rather than
+the full `@iconify/json` (439 MB). Browse the set at [icones.js.org](https://icones.js.org).
+
+## TypeScript
+
+**TypeScript 6** with full `.vue` support through `vue-tsc`. `tsconfig.json` is a solution file
+referencing three projects, and `pnpm type-check` builds all of them:
+
+| project              | covers                       |
+| -------------------- | ---------------------------- |
+| `tsconfig.app.json`  | `src/`, including unit specs |
+| `tsconfig.node.json` | the root `*.config.ts` files |
+| `e2e/tsconfig.json`  | the Playwright suite         |
+
+A project missing from `references` is silently skipped by `vue-tsc --build`, which is exactly how
+the e2e suite went unchecked for a while. If you add a fourth tsconfig, add it to `references` or it
+will not be type-checked and nothing will tell you.
+
+### Auto-imports
+
+[unplugin-auto-import](https://github.com/unplugin/unplugin-auto-import) handles composables and
+[unplugin-vue-components](https://github.com/unplugin/unplugin-vue-components) handles components,
+the latter with Reka UI's resolver registered so its primitives resolve by name too. Both write their
+declarations to the repo root (`auto-imports.d.ts`, `components.d.ts`) and **both files are
+committed**, so a fresh clone type-checks before anything has been run. CI asserts they are current
+with `git diff --exit-code`, alongside `src/typed-router.d.ts`.
+
+## Linting and formatting
+
+The honest ledger of what is and isn't covered:
+
+| Target                                       | Linted                                                                               | Formatted |
+| -------------------------------------------- | ------------------------------------------------------------------------------------ | --------- |
+| `.ts` / `.js`                                | eslint core, typescript, unicorn, oxc, import, promise, node — plus type-aware rules | yes       |
+| `.vue` `<script setup>`                      | full JS/TS rules + oxlint's native `vue` plugin                                      | yes       |
+| `.vue` `<template>`                          | `vize/*` rules via `oxlint-plugin-vize`                                              | yes       |
+| `*.spec.ts`                                  | oxlint's native `vitest` plugin                                                      | yes       |
+| `e2e/*.spec.ts`                              | oxlint core rules                                                                    | yes       |
+| `.md` / `.json` / `.yaml` / `.css` / `.html` | no                                                                                   | yes       |
+
+Vue template linting comes from [Vize](https://github.com/ubugeeei-prod/vize), a Rust Vue toolchain,
+bridged into oxlint as `vize/*` rules. `eslint-plugin-vue` cannot be ported to oxlint — it depends on
+`vue-eslint-parser` and its own AST — so this is the route to `v-for` key checks, `v-html` warnings,
+unused-component detection and a11y rules without bringing ESLint back.
+
+Five things worth knowing about the setup:
+
+1. **`pnpm lint` runs `oxlint-vize`, not `oxlint`.** Plain `oxlint` silently skips `.vue` files that
+   have no `<script>` block — two of this template's components are scriptless, so 25% of the
+   components would appear linted while not being linted at all. The wrapper works around it.
+2. **`pnpm lint:fix` stays on plain `oxlint`.** The wrapper cannot write fixes back yet ("fixes are
+   not applied back to original files yet"), so autofix uses oxlint directly.
+3. **`node_modules` must NOT be added to `ignorePatterns` in `.oxlintrc.json`.** The wrapper stages
+   temporary copies of scriptless SFCs under `node_modules/.vize/`, and ignoring that path silently
+   disables every template rule while still exiting 0. oxlint already skips `node_modules` by default
+   and respects `.gitignore`, so the entry is unnecessary as well as harmful.
+4. **`settings.vize.preset` is `"incremental"`.** Every other preset gates rules by bundle membership
+   and will keep explicitly-listed rules quiet. `incremental` runs exactly the `vize/*` rules
+   enumerated in `.oxlintrc.json` and nothing else.
+5. **`pnpm lint` passes `--type-aware`**, which turns on rules needing type information —
+   `no-floating-promises`, `await-thenable`, `no-misused-promises` and ~20 more. This requires the
+   `oxlint-tsgolint` package (a native binary, exact-pinned) and costs about 0.2s here. Note it
+   covers `.ts`/`.js` only, not `.vue` SFCs. The pre-commit hook deliberately runs plain `oxlint` for
+   speed; type-aware runs on pre-push and in CI.
+
+Two gaps remain:
+
+- **`no-unused-vars` is still inert inside `<script setup>`** — oxlint cannot see template usage, so
+  it cannot distinguish a template-consumed ref from a dead one (tracked upstream in
+  [oxc#15761](https://github.com/oxc-project/oxc/issues/15761)). `noUnusedLocals` and
+  `noUnusedParameters` in `tsconfig.app.json` mean `pnpm type-check` catches it instead.
+- **No UnoCSS class ordering or validation.** `@unocss/eslint-plugin` needs a Vue template AST.
+  `presetIcons({ warn: true })` at least surfaces typo'd icon names at build time.
+
+`oxlint-plugin-vize` is pre-1.0 and ships a native binary requiring **glibc 2.39+** (Ubuntu 24.04+,
+Debian 13+). To remove it: delete the `jsPlugins`, `settings` and `vize/*` rule entries from
+`.oxlintrc.json`, drop the `oxlint-vize` job from `lefthook.yaml`, and set `"lint": "oxlint ."`.
+Everything else keeps working.
+
+### Git hooks
+
+[Lefthook 2](https://github.com/evilmartians/lefthook) installs on `pnpm install` via the `prepare`
+script. `pre-commit` is piped rather than parallel — `oxlint --fix` writes first, then `oxfmt`
+formats its output, then `oxlint-vize` checks templates — because running the fixers in parallel
+would race on the same files. `pre-push` runs the full lint + format + type-check in parallel.
+
+## Testing
+
+End-to-end tests run against the Vite dev server locally for a fast feedback loop. CI builds first
+and tests the preview server:
+
+```sh
+pnpm build
+CI=1 pnpm test:e2e
+```
+
+Both layers are backed by the same MSW handlers, from opposite sides. The unit tests start
+`setupServer` in `src/test/setup.ts` with `onUnhandledRequest: 'error'` — a request nobody mocked is a
+bug in the test, not something to quietly let through — and reset the in-memory db between tests,
+since it is module state that would otherwise leak from one test's POST into the next test's GET. The
+Playwright suite drives the real service worker in a real browser, which is what notices when
+`public/mockServiceWorker.js` goes missing or stale.
+
+`vueDevTools` and `TurboConsole` are skipped under Vitest: both keep handles open that stop Vitest's
+Vite server from closing, adding a 10s "close timed out" stall to every `vitest run`.
+
+## Requirements
+
+- **Node 26** (see `.nvmrc`) and **pnpm 11**.
+- Note that **Node 26 is the Current channel, not LTS** — it enters LTS in October 2026, and Node 24
+  "Krypton" is today's Active LTS. `engines.node` is set to `>=26.0.0`, which pnpm enforces as a hard
+  install failure. If you fork this for production on an LTS line, relax that field.
+
+### Optional: reproducible shell with Nix
+
+If you have [devenv](https://devenv.sh) and [direnv](https://direnv.net):
+
+```sh
+direnv allow    # or: devenv shell
+```
+
+This pins Node 26.5.0, pnpm 11.15.0 and the Playwright browsers from nixpkgs. `devenv.nix`,
+`devenv.yaml` and `.envrc` are inert for everyone else — without Nix installed, `pnpm install` works
+exactly as normal.
+
+Two Nix-specific notes:
+
+- Playwright's own downloaded browsers are linked against FHS paths that don't exist on NixOS, so the
+  shell points `PLAYWRIGHT_BROWSERS_PATH` at the nixpkgs bundle instead. Browser revisions are
+  matched per Playwright release, which is why **`@playwright/test` is pinned exactly** (no caret) to
+  whatever `pkgs.playwright-driver` provides. `enterShell` warns if the two drift apart. On CI
+  neither variable is set and `playwright install --with-deps` behaves normally.
+- Node 26 no longer bundles corepack, so pnpm comes from nixpkgs. Keep `packageManager` in
+  `package.json` aligned with it, or pnpm's own version self-check will download a different pnpm
+  inside the shell.
+
+## Releases
+
+Releases are cut with [changelogen](https://github.com/unjs/changelogen) from
+[conventional commits](https://www.conventionalcommits.org). Configuration lives in
+`changelog.config.ts`, and it is deliberately almost empty — changelogen's defaults already produce
+the format this `CHANGELOG.md` has used since v3.0.0.
+
+```sh
+pnpm changelog     # what would the next entry look like? Prints to stdout, writes nothing.
+pnpm release       # cut it
+```
+
+`pnpm release` runs `changelogen --release --clean --push`, which:
+
+1. refuses to start if the working tree is dirty (`--clean`);
+2. derives the next version from the commits since the last tag — `feat:` bumps the minor,
+   `fix:`/`perf:`/`refactor:`/`docs:`/`build:` the patch, a `!` or `BREAKING CHANGE:` the major — and
+   writes it to `package.json`;
+3. prepends the new section to `CHANGELOG.md`, which the
+   [/changelog](https://vue-starter.raz.wtf/changelog) page renders as-is;
+4. commits `chore(release): vX.Y.Z`, creates an annotated `vX.Y.Z` tag, and pushes both
+   (`git push --follow-tags`);
+5. creates the matching GitHub release.
+
+Override the computed bump by appending the level: `pnpm release --major`.
+
+Step 5 needs a GitHub token, looked up in this order: `CHANGELOGEN_TOKENS_GITHUB`, `GITHUB_TOKEN`,
+`GH_TOKEN`, then the [`gh` CLI](https://cli.github.com) config. With none of them, the first four
+steps still happen and changelogen prints a pre-filled "create release" URL to open by hand.
+
+The push in step 4 goes through lefthook's `pre-push` hook, so lint, format and type-check run before
+anything reaches the remote. Nothing is ever published to npm — `package.json` is `private: true`.
+
+### Releasing from GitHub
+
+`.github/workflows/release.yml` reaches the same end state on a runner, with no token needed locally.
+It takes two steps rather than one, because a protected `main` accepts changes only through a pull
+request and the built-in `GITHUB_TOKEN` cannot bypass that:
+
+1. **Actions → Release → Run workflow**, with a `bump` input of `auto` (default), `patch`, `minor` or
+   `major`. This runs `pnpm check` and the unit tests, does steps 1–3 above, and opens a
+   `release/vX.Y.Z` pull request containing just the `CHANGELOG.md` and `package.json` diff.
+2. **Merge that PR.** The push to `main` triggers the workflow's `tag` job, which creates the
+   annotated `vX.Y.Z` tag and the GitHub release.
+
+The `tag` job recognises a release by the pair a release commit always leaves behind — a version in
+`package.json` with no tag yet, plus a matching `## vX.Y.Z` heading in `CHANGELOG.md` — so ordinary
+commits that touch `package.json` pass straight through it.
+
+Two things to know before tightening `main`'s protection further: a PR opened with `GITHUB_TOKEN`
+does not trigger `on: pull_request`, so CI does not run on the release PR (the workflow's own
+check/test steps are the gate instead), and adding **required status checks** would therefore
+deadlock every release PR unless the PR is opened with a PAT or GitHub App token instead.
+
+Two conventions worth keeping, since the changelog is only as good as the commits:
+
+- **`chore(deps): …` commits are dropped** from the changelog by changelogen unless they are
+  breaking. Dependabot/Renovate noise stays out on its own.
+- **Non-conventional commit messages are skipped entirely.** A change committed as `fixed the thing`
+  will not appear in any release.
+
+## Deployment
+
+Deployed to **Cloudflare Workers** as static assets, at
+[vue-starter.raz.wtf](https://vue-starter.raz.wtf).
+
+`wrangler.jsonc` is an assets-only Worker: no `main`, so no Worker code runs and Cloudflare serves
+`dist/` from its edge. Two details carry weight:
+
+- **`not_found_handling: "single-page-application"`.** vue-router runs in history mode, so `/demo`
+  matches no file on disk — without this, a hard refresh anywhere but `/` returns Cloudflare's 404.
+  Real files still take precedence, which is what keeps `/mockServiceWorker.js` working; a fallback to
+  `index.html` there would silently break the demo page.
+- **Worker, not Pages.** Pages is in maintenance mode and cannot grow server-side code. Adding a
+  `"main"` entry to `wrangler.jsonc` turns this into a full Worker with the same assets in front of
+  it, so an API route later is a config change rather than a migration.
+- **It is free.** [Requests to static assets are free and unlimited](https://developers.cloudflare.com/workers/platform/pricing/)
+  on both plans, and an assets-only Worker serves nothing else — so the free plan's 100,000
+  requests/day applies to Worker invocations you do not have. Free-plan asset limits are 20,000 files
+  per version and 25 MiB per file; this build ships 15. Cost-identical to Pages.
+
+The site answers on a **Custom Domain** (`routes` with `custom_domain: true`), which means Cloudflare
+creates the DNS record and manages the certificate — there is nothing to add by hand, but the zone
+must be in the same account as the Worker. `workers_dev` is off since the real domain covers it, and
+`preview_urls` is then set back to `true` explicitly: since wrangler 4.44 preview URLs default to
+matching `workers_dev`, so disabling the workers.dev route would otherwise take `cf:preview` with it.
+
+CI deploys on every push to `main`, from the `deploy` job in `.github/workflows/ci.yml`. It is gated
+behind `needs: ci`, so only a commit that passed lint, types, unit tests and e2e ever ships. Two
+repository secrets are required:
+
+| secret                  | where to get it                                                              |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | Cloudflare dashboard → My Profile → API Tokens → **Edit Cloudflare Workers** |
+| `CLOUDFLARE_ACCOUNT_ID` | Workers & Pages → Account details, or `wrangler whoami`                      |
+
+They are secrets rather than values in the workflow on purpose: this is a template, and a fork should
+not inherit someone else's account ID. With no token set the deploy job logs a notice and exits
+green, so forks do not get a red `main`.
+
+The token needs zone access, not just account access — attaching a Custom Domain writes a DNS record.
+The **Edit Cloudflare Workers** template covers it (`Workers Scripts:Edit`, `Workers Routes:Edit`,
+`Zone:Read`, `DNS:Edit`). A token hand-scoped to account permissions only will deploy the Worker and
+then fail on the route.
+
+To deploy by hand:
+
+```sh
+pnpm exec wrangler login
+pnpm run cf:deploy    # build + wrangler deploy
+pnpm run cf:preview   # build + wrangler versions upload — a preview URL, production untouched
+```
+
+Note the `pnpm run`: `pnpm deploy` is a built-in pnpm command for workspace pruning and will _not_
+run this script.

--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -6,3 +6,13 @@ test('visits the app root url', async ({ page }) => {
   await page.goto('/')
   await expect(page.locator('div.markdown-body > h1')).toHaveText('Vue 3 Starter')
 })
+
+// The docs page imports docs/reference.md — the only Markdown source outside the
+// repo root, and outside src/ entirely. If that path or the Markdown plugin's
+// `include` ever stops covering it, the route renders empty rather than failing
+// the build, so assert the content actually arrived.
+test('renders the reference docs from outside src/', async ({ page }) => {
+  await page.goto('/docs')
+  await expect(page.locator('div.markdown-body > h1')).toHaveText('Reference')
+  await expect(page.getByRole('heading', { name: 'The data layer', level: 2 })).toBeVisible()
+})

--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -11,6 +11,7 @@
 // to the link with aria-describedby, and opens on focus as well as hover.
 const links = [
   { to: '/', label: 'readme', file: 'index.vue', icon: 'i-lucide-house' },
+  { to: '/docs', label: 'docs', file: 'docs.vue', icon: 'i-lucide-book-open' },
   { to: '/demo', label: 'demo', file: 'demo.vue', icon: 'i-lucide-flask-conical' },
   { to: '/layout', label: 'layout', file: 'layout.vue', icon: 'i-lucide-layout-template' },
   { to: '/changelog', label: 'changelog', file: 'changelog.vue', icon: 'i-lucide-rotate-ccw' },

--- a/src/pages/docs.vue
+++ b/src/pages/docs.vue
@@ -1,0 +1,29 @@
+<script lang="ts" setup>
+import Reference from '../../docs/reference.md'
+
+definePage({
+  meta: {
+    layout: 'DefaultLayout',
+    title: 'Docs',
+    description: 'Vue Starter Template by Simone Colabufalo - github.com/RazorSiM',
+  },
+})
+
+useHead({
+  title: 'Docs',
+  meta: [
+    {
+      name: 'description',
+      content: 'Vue Starter reference: rationale, bundle costs and the sharp edges',
+    },
+  ],
+})
+</script>
+
+<template>
+  <!-- The long-form half of the README. It lives outside src/pages/ so the router,
+       which is scoped to `extensions: ['.vue']`, never treats it as a route of its own. -->
+  <div class="prose max-w-none dark:prose-invert">
+    <Reference />
+  </div>
+</template>

--- a/src/typed-router.d.ts
+++ b/src/typed-router.d.ts
@@ -52,6 +52,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/docs': RouteRecordInfo<
+      '/docs',
+      '/docs',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/layout': RouteRecordInfo<
       '/layout',
       '/layout',
@@ -91,6 +98,14 @@ declare module 'vue-router/auto-routes' {
     'src/pages/demo.vue': {
       routes:
         | '/demo'
+      views:
+        | never
+      pathParamNames:
+        | never
+    }
+    'src/pages/docs.vue': {
+      routes:
+        | '/docs'
       views:
         | never
       pathParamNames:


### PR DESCRIPTION
> **Note:** this PR contains only the README/docs split. The deployment-visibility
> work (badges, Actions environment, repo settings) is in a follow-up PR — an
> earlier revision of this description wrongly included it.

## Why

`README.md` doubles as the deployed homepage (`src/pages/index.vue` imports it), so it had steadily grown into a 429-line manual — great reference, poor landing page. This splits it by audience instead of just deleting content.

## What

| file | |
| --- | --- |
| `README.md` | **429 → 171 lines.** Landing page: intro, install, four compact stack tables, the data-layer map, requirements, scripts, deployment summary. |
| `docs/reference.md` + `src/pages/docs.vue` | **New `/docs` route** holding the depth: routing table, Reka UI inventory and its ~47 KB, MSW notes, the lint coverage ledger and its five gotchas, Nix caveats, release and Cloudflare detail. |
| `AGENTS.md` | Follows the [agents.md](https://agents.md/) format — overview, setup, "verify your work", architecture map, code style, testing, an 11-item **Traps** list, commit/release conventions, deployment. |
| `CLAUDE.md` | Symlink to `AGENTS.md`, per the migration pattern on agents.md. Committed as mode `120000`, 9 bytes — not a copy. |

Also drops the vestigial `create-vue` *"Customize Configuration → see the Vite docs"* section, and adds the `/docs` link to `TopNav.vue`.

## Notes on two deliberate choices

**No fragment links into `/docs`.** There's no `markdown-it-anchor` in the Markdown pipeline, so headings carry no `id`s and `#section` links would land on the page but never scroll. The link text names the section instead. Adding the plugin is documented in `docs/reference.md` as the fix if we ever want real anchors — the goal here was less, not more.

**`oxfmt` and the symlink.** Verified in isolation that `oxfmt` writes *through* `CLAUDE.md` to `AGENTS.md` and leaves the symlink intact. Atomic temp-and-rename would have silently turned it into a drifting copy, so no `ignorePatterns` guard was needed.

## Incidental fix

The deployment notes claimed the build *"ships 13 files"*; it's 15 with the docs chunk. Corrected.

## Verification

- `pnpm check` — lint, format, type-check clean
- `pnpm test` — 22 unit tests pass
- `CI=1 pnpm test:e2e` — 33 pass against the production preview (was 30)

The new e2e test guards the one fragile part: `docs/reference.md` is the only Markdown source outside `src/`, and if it fell out of the Markdown plugin's `include` the route would render **empty rather than fail the build**.

`/docs` is a lazy chunk (33.5 KB raw, 11.4 KB gzipped), so the homepage pays nothing for it.

## Caveat

Windows clones need `core.symlinks=true` (or Developer Mode), or `CLAUDE.md` checks out as a text file containing `AGENTS.md`. Harmless here, but this is a template — happy to swap it for a real file with a one-line pointer if you'd rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)