### PR TITLE
docs: surface the deployment and docs links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
+    # Gives the repo a native Deployments panel linking to the live site.
+    # wrangler-action does not create GitHub deployment records on its own.
+    # Caveat: a run where the deploy steps are skipped (a fork with no token)
+    # still records a deployment, since the environment is a job-level property.
+    environment:
+      name: production
+      url: https://vue-starter.raz.wtf
+
     # Required by wrangler-action to mint the OIDC token it uses for provenance.
     permissions:
       contents: read

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Vue 3 Starter
 
+[![CI](https://github.com/RazorSiM/vue-starter/actions/workflows/ci.yml/badge.svg)](https://github.com/RazorSiM/vue-starter/actions/workflows/ci.yml)
+[![Deployed on Cloudflare Workers](https://img.shields.io/badge/deployed-Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)](https://vue-starter.raz.wtf)
+[![Docs](https://img.shields.io/badge/docs-%2Fdocs-4FC08D?logo=vuedotjs&logoColor=white)](https://vue-starter.raz.wtf/docs)
+
 A comprehensive Vite + Vue 3 template, [deployed here](https://vue-starter.raz.wtf/).
 Requires **Node 26** and **pnpm 11**.
 


### PR DESCRIPTION
Follow-up to #162. Makes the deployment and the `/docs` page discoverable from the repo itself, in three places, with no duplicated content.

Cloudflare publishes **no deploy-status badge** (unlike Netlify/Vercel), so the CI workflow badge and the Actions environment URL are the only *real* signals available. The Cloudflare badge is decorative.

## Changes in this PR

**README badge row** — CI status, a Cloudflare "deployed" badge linking to the site, and a docs badge linking to `/docs`.

**`environment: {name: production, url: …}`** on the `deploy` job, which gives the repo a native **Deployments** panel with a live link. `wrangler-action` doesn't create GitHub deployment records on its own.

## Applied out of band (repo settings, not in this diff)

- **About → Website** pointed at *the repo itself* (`https://github.com/RazorSiM/vue-starter`) and now points at `https://vue-starter.raz.wtf`.
- The never-initialised **wiki is disabled**, so nobody lands on an empty page.

The wiki was considered and rejected as the docs home: it's a separate git repo, so content would sit outside PRs, CI and `oxfmt`, and it would become a third copy of docs that already exist as `docs/reference.md` and are already published at `/docs`.

## Two caveats worth knowing

- The **CI badge covers the whole workflow**, and the deploy job deliberately exits green when a fork has no `CLOUDFLARE_API_TOKEN` — so on a fork the badge means "CI passed", not "deployed".
- The **environment is a job-level property**, so a run where the deploy steps are skipped still records a deployment.

## Verification

- `pnpm check` and `pnpm test` (22 pass) clean on this branch, rebased onto current `main`
- `ci.yml` re-parsed after editing to confirm the `environment` block is well-formed
- All three badge URLs return 200, and the badges are confirmed compiled into the homepage chunk

## Caveat

Badges render on the **live homepage** too, since the README *is* the homepage — three external image requests per page load. If that bothers you, wrapping them in `<p class="badges">` plus `.badges { display: none }` hides them on the site while keeping them on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)