### PR TITLE
ci: pull request preview deployments, and deploy path hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+# Checking out is all most of this needs; `preview` asks for more where it needs it.
+# Set at the top so a job added later starts from read-only rather than from whatever
+# the repository default happens to be. Note that wrangler-action authenticates with
+# the API token, not with GitHub OIDC — nothing here needs `id-token`.
+permissions:
+  contents: read
+
+# One run at a time per branch. On a pull request a superseded run is cancelled,
+# which just saves minutes. On `main` it is queued instead: two pushes in quick
+# succession would otherwise race two `wrangler deploy`s, and the winner would be
+# whichever finished last rather than whichever commit is newer.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -45,10 +60,33 @@ jobs:
       - name: Generated files are up to date
         run: git diff --exit-code -- auto-imports.d.ts components.d.ts src/typed-router.d.ts
 
-      # No PLAYWRIGHT_BROWSERS_PATH here (that is the NixOS dev-shell path),
-      # so Playwright downloads its own browsers normally.
+      # The cache key has to be the browser revision, not the lockfile hash: the
+      # revisions ship with @playwright/test, so anything coarser either misses on
+      # every unrelated dependency bump or hits after a Playwright bump and runs the
+      # new client against the old binaries.
+      - name: Resolve the pinned Playwright version
+        id: playwright
+        run: echo "version=$(pnpm exec playwright --version | cut -d' ' -f2)" >> "$GITHUB_OUTPUT"
+
+      # ~400 MB for chromium + firefox + webkit, downloaded on every run before this.
+      # No PLAYWRIGHT_BROWSERS_PATH is set here (that is the NixOS dev-shell path), so
+      # Playwright uses its own default location, which is what gets cached.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps
+
+      # The cache holds the browsers but not the apt packages they link against,
+      # so a cache hit still needs the system libraries — just not the download.
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
 
       # CI=1 is set by Actions, so this tests `vite preview` on :4173 —
       # which is why the build step must come first.
@@ -56,7 +94,9 @@ jobs:
         run: pnpm run test:e2e
 
   # Static assets on a Cloudflare Worker. Gated behind `needs: ci`, so main only ever
-  # deploys a commit that passed lint, types, units and e2e.
+  # deploys a commit that passed lint, types, units and e2e. That gate is the reason
+  # this repo does not use Cloudflare's own git integration (Workers Builds): it
+  # triggers on push, in parallel with this workflow, with no way to wait for a check.
   deploy:
     needs: ci
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -69,10 +109,6 @@ jobs:
     environment:
       name: production
       url: https://vue-starter.raz.wtf
-
-    # Required by wrangler-action to mint the OIDC token it uses for provenance.
-    permissions:
-      contents: read
 
     steps:
       - uses: actions/checkout@v7
@@ -114,3 +150,81 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: pnpm
+
+  # `wrangler versions upload` puts the branch on its own
+  # <version>-vue-starter.0xraz.workers.dev URL without promoting it, so production
+  # keeps serving whatever `deploy` last shipped. This is what `preview_urls: true`
+  # in wrangler.jsonc is for.
+  preview:
+    needs: ci
+
+    # Only for pull requests opened from a branch of this repository. A fork's PR runs
+    # with no access to secrets, so the upload could not authenticate anyway — and
+    # `pull_request_target`, which would grant it, means running fork code with a
+    # writable token. Not worth a preview URL.
+    if: >-
+      github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    # To post the preview URL back onto the pull request.
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Same reasoning as in `deploy`: a fork should not get a red PR over a secret
+      # it was never going to have.
+      - name: Are Cloudflare credentials configured?
+        id: credentials
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -n "$CLOUDFLARE_API_TOKEN" ]; then
+            echo 'ready=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'ready=false' >> "$GITHUB_OUTPUT"
+            echo '::notice::CLOUDFLARE_API_TOKEN is not set — skipping the preview.'
+          fi
+
+      - name: Build
+        if: steps.credentials.outputs.ready == 'true'
+        run: pnpm run build-only
+
+      # wrangler writes a machine-readable artifact per command, and the action reads
+      # `preview_url` out of it into `deployment-url` — so no parsing the log.
+      - name: Upload a preview version
+        id: upload
+        if: steps.credentials.outputs.ready == 'true'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: pnpm
+          command: versions upload
+
+      # `--edit-last --create-if-none` rewrites this workflow's own previous comment
+      # instead of appending one per push, so a long-lived PR gets one comment that
+      # always points at the current head.
+      - name: Comment the preview URL on the pull request
+        if: steps.credentials.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.upload.outputs.deployment-url }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          body=$(printf '**Preview:** %s\n\nUploaded from `%s`. This is an unpromoted Worker version, so [production](https://vue-starter.raz.wtf) is untouched.' \
+            "$PREVIEW_URL" "$SHA")
+          gh pr comment "$PR" --edit-last --create-if-none --body "$body"

--- a/README.md
+++ b/README.md
@@ -145,8 +145,9 @@ Deployed to **Cloudflare Workers** as static assets, at
 [free and unlimited](https://developers.cloudflare.com/workers/platform/pricing/) on both plans.
 
 CI deploys on every push to `main`, gated behind the `ci` job, so only a commit that passed lint,
-types, unit tests and e2e ever ships. A fork without Cloudflare secrets logs a notice and exits
-green rather than turning `main` red.
+types, unit tests and e2e ever ships. Pull requests from a branch of this repository get a preview
+version uploaded to its own URL, commented onto the PR, with production left alone. A fork without
+Cloudflare secrets logs a notice and exits green rather than turning `main` red.
 
 ```sh
 pnpm run cf:deploy    # build + wrangler deploy

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -397,6 +397,48 @@ The **Edit Cloudflare Workers** template covers it (`Workers Scripts:Edit`, `Wor
 `Zone:Read`, `DNS:Edit`). A token hand-scoped to account permissions only will deploy the Worker and
 then fail on the route.
 
+The workflow sets a `concurrency` group per branch. On a pull request a superseded run is cancelled,
+which only saves minutes; on `main` runs queue instead, because two pushes in quick succession would
+otherwise race two `wrangler deploy`s and the winner would be whichever finished last rather than
+whichever commit is newer.
+
+### Preview deployments
+
+A pull request opened from a branch of this repository gets a preview version, from the `preview` job.
+It runs `wrangler versions upload` — which uploads a version without promoting it, so production
+keeps serving whatever `deploy` last shipped — and comments the resulting
+`<version>-vue-starter.0xraz.workers.dev` URL onto the PR. This is what `preview_urls: true` in
+`wrangler.jsonc` is for. The comment is rewritten in place on each push rather than appended, so a
+long-lived PR has one comment that always points at the current head.
+
+It is skipped for pull requests from forks. Those run with no access to secrets, so the upload could
+not authenticate anyway, and `pull_request_target` — which would grant it — means running fork code
+with a writable token.
+
+### Why not Cloudflare's git integration?
+
+Cloudflare can build and deploy a Worker itself, by connecting the repository to it:
+[Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/), the successor to the Pages
+git integration. It is tempting — it would remove both secrets above, since Cloudflare mints its own
+token, and it posts preview URLs and GitHub check runs for free. This repo deliberately does not use
+it, for two reasons:
+
+- **It cannot wait for a check.** A build triggers on push and runs in parallel with this workflow,
+  with no "wait for status checks" setting, so a commit that fails e2e still reaches production. The
+  `needs: ci` gate has no equivalent there. Moving the whole gate into the build command is not a
+  real substitute either: e2e needs `playwright install --with-deps`, which wants `apt` inside the
+  build container.
+- **The toolchain pins would leave the repo.** The
+  [build image](https://developers.cloudflare.com/workers/ci-cd/builds/build-image/) defaults to Node
+  22 and pnpm 10. `.nvmrc` is honoured, so Node 26 is picked up, but `engines.pnpm` here is `>=11`,
+  which pnpm enforces as a hard install failure — so pnpm would have to be pinned with a
+  `PNPM_VERSION` build variable in the Cloudflare dashboard, along with the build and deploy
+  commands. For a template whose point is that you can read how it works from the files, moving
+  deployment config into dashboard state is a bad trade.
+
+The one thing genuinely worth having from it, a preview URL per pull request, is in the `preview` job
+instead.
+
 To deploy by hand:
 
 ```sh


### PR DESCRIPTION
## Why

Prompted by a read of Cloudflare's [migrate from Pages](https://developers.cloudflare.com/workers/static-assets/migration-guides/migrate-from-pages/) guide and the question of whether the Actions deploy could be replaced by connecting the repo to Cloudflare directly ([Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/)).

It can, but it shouldn't here:

- **It cannot wait for a check.** A build triggers on push and runs in parallel with CI, so a commit that fails e2e still reaches production. There is no equivalent of `needs: ci`. Putting the gate in the build command is not a substitute — e2e needs `playwright install --with-deps`, which wants `apt` inside the build container.
- **The toolchain pins would leave the repo.** The build image defaults to Node 22 and pnpm 10. `.nvmrc` is honoured so Node 26 is fine, but `engines.pnpm` is `>=11`, which pnpm enforces as a hard install failure — so pnpm would need a `PNPM_VERSION` build variable in the dashboard, alongside the build and deploy commands. For a template whose point is that you can read how it works from the files, that is a bad trade.

So: keep Actions as the deployer, and take the one thing Workers Builds was actually offering.

## What changed

**Preview deployments.** A new `preview` job runs `wrangler versions upload` on PRs from a branch of this repository and comments the URL. Production is untouched — the version is never promoted. `wrangler-action` reads `preview_url` out of wrangler's output artifact into its `deployment-url` output, so there is no log scraping. `--edit-last --create-if-none` rewrites its own comment on each push instead of appending one per push.

Skipped for fork PRs: they run with no access to secrets, so the upload could not authenticate, and `pull_request_target` — which would grant it — means running fork code with a writable token.

**A concurrency group per branch.** Superseded PR runs are cancelled, which just saves minutes. Runs on `main` queue instead: two pushes in quick succession would otherwise race two `wrangler deploy`s, and the winner would be whichever finished last rather than whichever commit is newer.

**Playwright browsers cached**, keyed on the resolved version rather than the lockfile hash — a lockfile key would either miss on every unrelated dependency bump, or hit after a Playwright bump and run the new client against old binaries. Cache hits still run `install-deps`, since the apt packages are not in the cache path. That is ~400 MB of chromium + firefox + webkit downloaded on every run before this.

**`permissions: contents: read` moved to the workflow level**, and the comment claiming wrangler-action needs it to mint an OIDC token is gone. It does not; it authenticates with the API token, and OIDC would want `id-token: write`.

**Docs.** `README.md` and `docs/reference.md` are rendered as pages of the deployed app, so the second commit updates the `/docs` page too — a "Preview deployments" section and a "Why not Cloudflare's git integration?" section, so the above does not have to be re-litigated from scratch later.

## Done alongside, not in this diff

`main` had branch protection but **no required status checks** — the `needs: ci` gate in the deploy job was the only thing keeping a red commit off production, and it only caught it after the merge. `ci` is now a required check with `strict: true` (branches must be up to date before merging), pinned to the GitHub Actions app id. `preview` is deliberately not required, since a check that is skipped on fork PRs would block them forever.

## Verification

`pnpm check`, `pnpm test` (22 passing), `pnpm build-only`, and the generated-declarations diff all pass locally. This PR is itself the first live exercise of the `preview` job — expect a preview URL in a comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)