### PR TITLE
fix: make the header fit narrow viewports

### DIFF
--- a/src/components/TopNav.vue
+++ b/src/components/TopNav.vue
@@ -9,6 +9,12 @@
 // attach text to a control: it never opens on keyboard focus, never on touch, and
 // screen readers treat it inconsistently. Reka's Tooltip renders real text, wires it
 // to the link with aria-describedby, and opens on focus as well as hover.
+//
+// Below `sm` the labels collapse and only the icons remain: five labelled links need
+// 462px, which does not fit a 375px phone alongside the wordmark and the theme
+// toggle. The label stays in the DOM as `sr-only` rather than being dropped, because
+// the tooltip cannot be the accessible name here — it is wired with
+// aria-describedby, and it never opens on touch at all.
 const links = [
   { to: '/', label: 'readme', file: 'index.vue', icon: 'i-lucide-house' },
   { to: '/docs', label: 'docs', file: 'docs.vue', icon: 'i-lucide-book-open' },
@@ -27,11 +33,11 @@ const links = [
       <TooltipTrigger as-child>
         <RouterLink
           :to="link.to"
-          class="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm text-gray-500 font-mono transition hover:(bg-gray-200/70 text-gray-900) focus-visible:(outline-2 outline-indigo-500 outline-offset-2) dark:text-gray-400 dark:hover:(bg-gray-800 text-gray-100)"
+          class="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-sm text-gray-500 font-mono transition sm:px-2.5 hover:(bg-gray-200/70 text-gray-900) focus-visible:(outline-2 outline-indigo-500 outline-offset-2) dark:text-gray-400 dark:hover:(bg-gray-800 text-gray-100)"
           exact-active-class="bg-indigo-500/10 !text-indigo-600 dark:!text-indigo-300"
         >
-          <div :class="link.icon" class="h-4 w-4" aria-hidden="true" />
-          <span>{{ link.label }}</span>
+          <div :class="link.icon" class="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span class="sr-only sm:not-sr-only">{{ link.label }}</span>
         </RouterLink>
       </TooltipTrigger>
 

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -23,19 +23,25 @@ const sourceFile = computed(() => {
     <header
       class="sticky top-0 z-50 border-b border-gray-200 bg-gray-50/85 backdrop-blur dark:(border-gray-800 bg-gray-950/85)"
     >
-      <div class="mx-auto max-w-3xl flex items-center gap-4 px-6 py-3">
+      <div class="mx-auto max-w-5xl flex items-center gap-3 px-6 py-3 sm:gap-4">
         <div class="min-w-0 flex items-center gap-3">
-          <span class="text-sm font-mono font-semibold tracking-tight">vue-starter</span>
+          <!-- shrink-0, or flex resolves the overflow by wrapping the wordmark to
+               "vue-" / "starter" instead of truncating the path chip built for it. -->
+          <span class="shrink-0 text-sm font-mono font-semibold tracking-tight">vue-starter</span>
+          <!-- min-w-0 has to be on this span too: `truncate` only shrinks when every
+               flex ancestor between it and the overflow allows it, and the outer div
+               having min-w-0 is not enough. The chip is the one element here that is
+               meant to give way, so it is also the only shrinkable one. -->
           <span
-            class="hidden items-center gap-1.5 text-xs text-gray-500 font-mono sm:inline-flex dark:text-gray-500"
+            class="hidden min-w-0 items-center gap-1.5 text-xs text-gray-500 font-mono lg:inline-flex dark:text-gray-500"
           >
             <span class="truncate">{{ sourceFile }}</span>
             <div class="i-lucide-arrow-right h-3 w-3 shrink-0" aria-hidden="true" />
-            <span class="text-indigo-600 dark:text-indigo-400">{{ route.path }}</span>
+            <span class="shrink-0 text-indigo-600 dark:text-indigo-400">{{ route.path }}</span>
           </span>
         </div>
 
-        <div class="ml-auto flex items-center gap-1">
+        <div class="ml-auto flex shrink-0 items-center gap-1">
           <TopNav />
           <button
             type="button"


### PR DESCRIPTION
Adding the `/docs` nav link pushed the header past its width budget. What looked like one cramped header was three separate faults.

## What was wrong

| viewport | symptom |
| --- | --- |
| 375px | **161px of horizontal page overflow**; `changelog` clipped, theme toggle off-screen and unreachable |
| ~640–780px | wordmark wrapped to `vue-` / `starter` |
| every width | the `src/pages/…` chip has `truncate` but never truncated |

Measured on `/changelog`, the widest route: the header row needs **875px**, while `max-w-3xl` caps the bar's content box at **~705px** — and it caps it at *every* viewport, so no breakpoint could have rescued the chip.

## What changed

- **`TopNav`**: labels become `sr-only` below `sm`, leaving the icons, which takes the nav from 462px to 168px. The labels stay in the DOM rather than being dropped, because the tooltip cannot serve as the accessible name here — it is wired with `aria-describedby`, and it never opens on touch at all. Link padding tightens to `px-2` below `sm`.
- **`DefaultLayout`**: `shrink-0` on the wordmark so flex stops squeezing it, `min-w-0` on the chip span so its `truncate` actually engages, `shrink-0` on the nav group and the route path.
- **The bar goes `max-w-3xl` → `max-w-5xl`**, and the chip waits for `lg` instead of `sm`. This is the deliberate trade: the chrome is now wider than the reading column, so the wordmark no longer aligns with the `h1`. The alternative was dropping the nav labels on desktop permanently, which costs more than the alignment does.

## Verification

Width sweep from 320px to 1600px on `/changelog`, asserting page overflow, wordmark line count, chip truncation, and whether any link or the toggle escapes the viewport:

| width | overflow | wordmark | labels | chip | clipped |
| --- | --- | --- | --- | --- | --- |
| 320 | 0 | 1 line | icons | hidden | 0 |
| 375 | 0 | 1 line | icons | hidden | 0 |
| 414 | 0 | 1 line | icons | hidden | 0 |
| 640 | 0 | 1 line | text | hidden | 0 |
| 768 | 0 | 1 line | text | hidden | 0 |
| 1024 | 0 | 1 line | text | full (166px) | 0 |
| 1280 | 0 | 1 line | text | full (166px) | 0 |
| 1600 | 0 | 1 line | text | full (166px) | 0 |

All five links keep their accessible names at every width. `pnpm check` green, 22 unit tests pass, 33 e2e pass across chromium, firefox and webkit.

No test was added for this, so the next nav item can reintroduce it silently — worth a follow-up if you want the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
